### PR TITLE
limit image width to 66%

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,9 +84,10 @@ async function main() {
     console.log(chalk.green.bold("✓ Markdown successfully parsed! Starting pdf generation."))
     const outDir = path.join(__dirname, "out", `${inDir}.pdf`)
     await mdToPdf(
-      { content: markdown },
+      { content: markdown,  },
       {
         dest: outDir,
+        css: `img { max-width: 66%; }`, 
         basedir: path.join(IMPORT_PATH, inDir, "media"),
       }
     )


### PR DESCRIPTION
@profinjg using the dimensions from the json wasn't possible. this PR limits the image width to 66% of the page width. maybe this is sufficient?